### PR TITLE
fix: update add room feature

### DIFF
--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="save_room">Save Room</string>
     <string name="add_features">Add Features</string>
     <string name="add_photos">Add Photos</string>
+    <string name="select_photos">Select Photos</string>
     <string name="select_location">Select Location</string>
     <string name="selected_room_images">Selected room images</string>
     <string name="name_empty">Name value is empty</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -36,6 +36,12 @@
     <string name="add_features">Add Features</string>
     <string name="add_photos">Add Photos</string>
     <string name="select_location">Select Location</string>
+    <string name="selected_room_images">Selected room images</string>
+    <string name="name_empty">Name value is empty</string>
+    <string name="location_empty">Location value is empty</string>
+    <string name="features_empty">Features value is empty</string>
+    <string name="images_empty">Select images</string>
+    <string name="add_success">Successfully added room</string>
     <string name="room_capacity">Room capacity</string>
     <string name="negative_room">Room cannot be negative</string>
     <string name="close_organization_type">Close type of organization</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -41,6 +41,8 @@
     <string name="name_empty">Name value is empty</string>
     <string name="location_empty">Location value is empty</string>
     <string name="features_empty">Features value is empty</string>
+    <string name="add_room_button">Add room button</string>
+    <string name="add_room_counter">Add room counter</string>
     <string name="images_empty">Select images</string>
     <string name="add_success">Successfully added room</string>
     <string name="room_capacity">Room capacity</string>

--- a/ui/admin/src/main/java/com/amalitech/admin/di/AdminPresentationModule.kt
+++ b/ui/admin/src/main/java/com/amalitech/admin/di/AdminPresentationModule.kt
@@ -1,16 +1,21 @@
 package com.amalitech.admin.di
 
 import com.amalitech.admin.room.AddRoomViewModel
+import com.amalitech.admin.room.usecase.AddRoom
 import com.amalitech.admin.room.usecase.GetLocation
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 val adminPresentationModule = module {
     viewModel {
-        AddRoomViewModel(get())
+        AddRoomViewModel(get(), get())
     }
 
     single {
         GetLocation()
+    }
+
+    single {
+        AddRoom()
     }
 }

--- a/ui/admin/src/main/java/com/amalitech/admin/room/AddRoomScreen.kt
+++ b/ui/admin/src/main/java/com/amalitech/admin/room/AddRoomScreen.kt
@@ -1,8 +1,8 @@
 package com.amalitech.admin.room
 
-import android.net.Uri
 import android.view.KeyEvent
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
@@ -36,7 +36,6 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -85,11 +84,11 @@ fun AddRoomScreen(
     }
     val focusManager: FocusManager = LocalFocusManager.current
 
-    var selectImages by remember { mutableStateOf(listOf<Uri>()) }
     val galleryLauncher =
-        rememberLauncherForActivityResult(ActivityResultContracts.GetMultipleContents()) {
-            selectImages = it
+        rememberLauncherForActivityResult(ActivityResultContracts.PickMultipleVisualMedia()) {
+            viewModel.onRoomImages(it)
         }
+
     val spacing = LocalSpacing.current
 
     Surface(
@@ -142,7 +141,11 @@ fun AddRoomScreen(
             ) {
                 IconButton(
                     onClick = {
-                        galleryLauncher.launch("image/*")
+                        galleryLauncher.launch(
+                            PickVisualMediaRequest(
+                                mediaType = ActivityResultContracts.PickVisualMedia.ImageOnly
+                            )
+                        )
                     },
                     modifier = Modifier
                         .align(Alignment.Center)
@@ -168,8 +171,26 @@ fun AddRoomScreen(
                         width = Dimension.fillToConstraints
                     }
             ) {
+                if (state.imagesList.isEmpty()) {
+                    item {
+                        Text(
+                            text = stringResource(com.amalitech.core.R.string.select_photos),
+                            modifier = Modifier
+                                .constrainAs(add_photos) {
+                                    top.linkTo(parent.top, spacing.spaceMedium) // set to 48.dp
+                                    start.linkTo(parent.start, spacing.spaceMedium)
+                                    end.linkTo(parent.end, spacing.spaceSmall)
+                                    width = Dimension.fillToConstraints
+                                },
+                            color = MaterialTheme.colorScheme.outlineVariant,
+                            textAlign = TextAlign.Start,
+                            fontWeight = FontWeight.Light,
+                            fontSize = 16.sp
+                        )
+                    }
+                }
                 items(
-                    items = selectImages,
+                    items = state.imagesList,
                     itemContent = { uri ->
                         Image(
                             painter = rememberImagePainter(uri),
@@ -179,14 +200,14 @@ fun AddRoomScreen(
                             ),
                             modifier = Modifier
                                 .size(85.dp, 66.dp)
-                                .clip(RoundedCornerShape(4.dp))
+                                .clip(RoundedCornerShape(spacing.spaceExtraSmall))
                                 .padding(spacing.spaceExtraSmall)
                         )
                     })
             }
 
             LazyColumn(
-                verticalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(spacing.spaceSmall),
                 contentPadding = PaddingValues(
                     vertical = spacing.spaceSmall
                 ),
@@ -212,7 +233,7 @@ fun AddRoomScreen(
                             keyboardType = KeyboardType.Text
                         ),
                         onGo = {
-                            viewModel.onSaveRoomClick(selectImages)
+                            viewModel.onSaveRoomClick()
                         },
                         hasError = state.error
                     )
@@ -265,7 +286,7 @@ fun AddRoomScreen(
                             keyboardType = KeyboardType.Text
                         ),
                         onGo = {
-                            viewModel.onSaveRoomClick(selectImages)
+                            viewModel.onSaveRoomClick()
                         },
                         singleLine = false
                     )
@@ -275,7 +296,7 @@ fun AddRoomScreen(
                     DefaultButton(
                         text = stringResource(com.amalitech.core.R.string.save_room),
                         onClick = {
-                            viewModel.onSaveRoomClick(selectImages)
+                            viewModel.onSaveRoomClick()
                         },
                         modifier = Modifier.fillMaxWidth(),
                         backgroundColor = MaterialTheme.colorScheme.inversePrimary,

--- a/ui/admin/src/main/java/com/amalitech/admin/room/AddRoomScreen.kt
+++ b/ui/admin/src/main/java/com/amalitech/admin/room/AddRoomScreen.kt
@@ -181,7 +181,8 @@ fun AddRoomScreen(
                                     start.linkTo(parent.start, spacing.spaceMedium)
                                     end.linkTo(parent.end, spacing.spaceSmall)
                                     width = Dimension.fillToConstraints
-                                },
+                                }
+                                .padding(spacing.spaceMedium),
                             color = MaterialTheme.colorScheme.outlineVariant,
                             textAlign = TextAlign.Start,
                             fontWeight = FontWeight.Light,

--- a/ui/admin/src/main/java/com/amalitech/admin/room/AddRoomScreen.kt
+++ b/ui/admin/src/main/java/com/amalitech/admin/room/AddRoomScreen.kt
@@ -430,7 +430,7 @@ fun RoomTextFieldPreview() {
             mutableStateOf("")
         }
         RoomTextField(
-            placeholder = "Room Name",
+            placeholder = stringResource(com.amalitech.core.R.string.add_room),
             value = value,
             onValueChange = { value = it },
             modifier = Modifier.fillMaxWidth(),

--- a/ui/admin/src/main/java/com/amalitech/admin/room/AddRoomScreen.kt
+++ b/ui/admin/src/main/java/com/amalitech/admin/room/AddRoomScreen.kt
@@ -155,7 +155,9 @@ fun AddRoomScreen(
                 ) {
                     Icon(
                         imageVector = Icons.Filled.Add,
-                        contentDescription = null,
+                        contentDescription = stringResource(
+                            id = com.amalitech.core.R.string.add_room_button
+                        ),
                         modifier = Modifier.size(50.dp),
                         tint = MaterialTheme.colorScheme.onBackground
                     )
@@ -330,7 +332,9 @@ fun RoomCounter(
     ) {
         Icon(
             imageVector = Icons.Filled.Remove,
-            contentDescription = null,
+            contentDescription = stringResource(
+                id = com.amalitech.core.R.string.add_room_counter
+            ),
             modifier = Modifier
                 .clickable(
                     onClick = {
@@ -355,7 +359,9 @@ fun RoomCounter(
 
         Icon(
             imageVector = Icons.Filled.Add,
-            contentDescription = null,
+            contentDescription =  stringResource(
+                id = com.amalitech.core.R.string.add_room_counter
+            ),
             modifier = Modifier
                 .clickable(
                     onClick = {

--- a/ui/admin/src/main/java/com/amalitech/admin/room/AddRoomUiState.kt
+++ b/ui/admin/src/main/java/com/amalitech/admin/room/AddRoomUiState.kt
@@ -1,10 +1,22 @@
 package com.amalitech.admin.room
 
+import android.net.Uri
+
 data class AddRoomUiState(
     val name: String = "",
     val capacity: Int = 1,
     val location: String = "",
     val locationList: List<String> = listOf(),
+    val imagesList: List<Uri> = listOf(),
     val features: String = "",
     val error: Pair<Boolean, String> = Pair(false, "")
+)
+
+// TODO: move to domain room module, after its creation
+data class Room(
+    val name: String,
+    val capacity: Int,
+    val location: String,
+    val imagesList: List<Uri>,
+    val features: String
 )

--- a/ui/admin/src/main/java/com/amalitech/admin/room/AddRoomViewModel.kt
+++ b/ui/admin/src/main/java/com/amalitech/admin/room/AddRoomViewModel.kt
@@ -1,10 +1,11 @@
 package com.amalitech.admin.room
 
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.amalitech.admin.room.usecase.AddRoom
 import com.amalitech.admin.room.usecase.GetLocation
 import com.amalitech.core_ui.util.SnackbarManager
-import com.amalitech.core_ui.util.SnackbarMessage
 import com.amalitech.core_ui.util.SnackbarMessage.Companion.toSnackbarMessage
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
@@ -14,7 +15,8 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class AddRoomViewModel(
-    private val getLocation: GetLocation
+    private val getLocation: GetLocation,
+    private val addRoom: AddRoom
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(
         AddRoomUiState()
@@ -76,25 +78,28 @@ class AddRoomViewModel(
         }
     }
 
-    fun onSaveRoomClick() {
+    // TODO: cadet => these snack bar error messages will only show after the feature has been connected to the scaffold
+    fun onSaveRoomClick(selectImages: List<Uri>) {
         when {
             _uiState.value.name.isBlank() -> {
                 // TODO: this is an alternative way of handling errors, and using is error / supporting text in the ui
                 updateStateWithError(true, "Name value is empty")
-                SnackbarManager
-                    .showMessage(SnackbarMessage.StringSnackbar("Name value is empty"))
+                SnackbarManager.showMessage(com.amalitech.core.R.string.name_empty)
                 return
             }
 
             _uiState.value.location.isBlank() -> {
-                SnackbarManager
-                    .showMessage(SnackbarMessage.StringSnackbar("Location value is empty"))
+                SnackbarManager.showMessage(com.amalitech.core.R.string.location_empty)
                 return
             }
 
             _uiState.value.features.isBlank() -> {
-                SnackbarManager
-                    .showMessage(SnackbarMessage.StringSnackbar("Features value is empty"))
+                SnackbarManager.showMessage(com.amalitech.core.R.string.features_empty)
+                return
+            }
+
+            selectImages.isEmpty() -> {
+                SnackbarManager.showMessage(com.amalitech.core.R.string.images_empty)
                 return
             }
 
@@ -102,10 +107,35 @@ class AddRoomViewModel(
         }
 
         launchCatching {
-
+            addRoom(
+                mapRoomToDomain(
+                    _uiState.value.name,
+                    _uiState.value.location,
+                    _uiState.value.features,
+                    _uiState.value.capacity,
+                    selectImages
+                )
+            )
         }
     }
 
+    private fun mapRoomToDomain(
+        name: String,
+        location: String,
+        features: String,
+        capacity: Int,
+        selectImages: List<Uri>
+    ): Room {
+        return Room(
+            name,
+            capacity,
+            location,
+            selectImages,
+            features
+        )
+    }
+
+    // TODO: this is an alternative, so it can just be deleted if not needed
     private fun updateStateWithError(isError: Boolean, message: String) {
         _uiState.update { addRoomUiState ->
             addRoomUiState.copy(

--- a/ui/admin/src/main/java/com/amalitech/admin/room/AddRoomViewModel.kt
+++ b/ui/admin/src/main/java/com/amalitech/admin/room/AddRoomViewModel.kt
@@ -38,6 +38,15 @@ class AddRoomViewModel(
         }
     }
 
+    fun onRoomImages(images: List<@JvmSuppressWildcards Uri>) {
+        _uiState.update { addRoomUiState ->
+            addRoomUiState.copy(
+                imagesList = images
+            )
+        }
+    }
+
+
     fun onRoomName(roomName: String) {
         _uiState.update { addRoomUiState ->
             addRoomUiState.copy(
@@ -79,7 +88,7 @@ class AddRoomViewModel(
     }
 
     // TODO: cadet => these snack bar error messages will only show after the feature has been connected to the scaffold
-    fun onSaveRoomClick(selectImages: List<Uri>) {
+    fun onSaveRoomClick() {
         when {
             _uiState.value.name.isBlank() -> {
                 // TODO: this is an alternative way of handling errors, and using is error / supporting text in the ui
@@ -98,7 +107,7 @@ class AddRoomViewModel(
                 return
             }
 
-            selectImages.isEmpty() -> {
+            _uiState.value.imagesList.isEmpty() -> {
                 SnackbarManager.showMessage(com.amalitech.core.R.string.images_empty)
                 return
             }
@@ -113,7 +122,7 @@ class AddRoomViewModel(
                     _uiState.value.location,
                     _uiState.value.features,
                     _uiState.value.capacity,
-                    selectImages
+                    _uiState.value.imagesList
                 )
             )
         }

--- a/ui/admin/src/main/java/com/amalitech/admin/room/usecase/AddRoom.kt
+++ b/ui/admin/src/main/java/com/amalitech/admin/room/usecase/AddRoom.kt
@@ -1,0 +1,14 @@
+package com.amalitech.admin.room.usecase
+
+import com.amalitech.admin.room.Room
+import com.amalitech.core_ui.util.SnackbarManager
+
+// TODO: This is where we shall inject the repo(or some data source), after the room module merge
+class AddRoom {
+    operator fun invoke(
+        room: Room
+    ) = SnackbarManager.showMessage(com.amalitech.core.R.string.add_success)
+}
+
+
+


### PR DESCRIPTION
For instance, 
(DONE)you have a lazy row in which there are single items. Why don't you use a column
with a vertical scroll modifier? 

(DONE)And I think you can achieve the screen without a constraint layout (I may be wrong BTW).
Margin and padding can be added using our local spacing variable, as most of them exist.

(DONE)The icon button is not working (on click), 

(DONE)and you display a list of 100+ elements that are the same image obtained from local 
resources. 

(DONE)the text fields are of type password, and you use hard-coded values in the ViewModel 
for strings, etc.

![tw](https://github.com/AmaliTech-Training-Rw/Meeting-Room-booking-App/assets/28810111/c08b4ee0-9584-4559-8e0f-42508f1e5ff0)

![add](https://github.com/AmaliTech-Training-Rw/Meeting-Room-booking-App/assets/28810111/cd8fad3f-b860-4ec7-bfa6-aae0fbd893e5)
